### PR TITLE
Fix: Changed npm ci to install, ci does not work because of issues be…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
         working-directory: backend
 
       - name: Lint backend


### PR DESCRIPTION
- I changed the `npm ci` to `npm install`, the `package.json` and `package-lock.json` are not in sync so this causes issues. The speedup of *clean install* compared to normal instal wasn't that big anyway. 