### PR TITLE
Feat: Scripts for making backups on server

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -36,3 +36,4 @@ services:
 
 volumes:
   pg_data:
+    driver: local

--- a/scripts/server/backup_db.sh
+++ b/scripts/server/backup_db.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Timestamp voor unieke bestandsnamen
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+BACKUP_DIR="/backups"
+BACKUP_FILE="$BACKUP_DIR/db_backup_$TIMESTAMP.sql"
+
+mkdir -p $BACKUP_DIR
+
+# Maak een PostgreSQL backup en sla deze extern op
+docker exec prod-database-1 pg_dump -U postgres -F c -b -v -f /tmp/backup.sql dwengo-database
+docker cp prod-database-1:/tmp/backup.sql $BACKUP_FILE
+
+# Oude backups opruimen (max 7 backups)
+find $BACKUP_DIR -type f -name "*.sql" -mtime +7 -exec rm {} \;
+
+echo "Backup opgeslagen: $BACKUP_FILE"

--- a/scripts/server/prune_volumes.sh
+++ b/scripts/server/prune_volumes.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Zoek alle volumes behalve 'prod_pg_data'
+VOLUMES=$(docker volume ls -f dangling=true -q | grep -v "^prod_pg_data$")
+
+# Verwijder alleen de ongebruikte volumes, behalve 'prod_pg_data'
+if [ -n "$VOLUMES" ]; then
+  echo "Verwijderen van ongebruikte volumes behalve prod_pg_data..."
+  docker volume rm $VOLUMES
+  echo "Ongebruikte volumes succesvol verwijderd."
+else
+  echo "Geen ongebruikte volumes om te verwijderen."
+fi


### PR DESCRIPTION
- Added 2 scripts on the server
  - `backup_db.sh`
    - A script that makes a backup (`.sql` file), this script will be executed by a *cronjob* every day.
  - `prune_volumes.sh`
    - A script that *prunes* all **unused volumes** and skips the volume `prod_pg_data` even if it is dangling (not used by any container), this way the data in the DB will never be removed unless someone manually does so. This script will  be executed every 30m by a cronjob, together with the `docker system prune`.
- Made small changes on the server. 

This PR closes #352 