### PR TITLE
370-server-deploy-i18n

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -33,6 +33,7 @@ services:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
       retries: 5
+    restart: always
 
 volumes:
   pg_data:

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -26,7 +26,8 @@
           "builder": "@angular-devkit/build-angular:application",
           "options": {
             "localize": [
-              "en-US"
+              "en-US",
+              "nl"
             ],
             "outputPath": "dist/frontend",
             "index": "src/index.html",

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,6 +1,9 @@
-import { Environment } from "./environment";
+interface Environment {
+    production: boolean;
+    API_URL: string;
+}
 
 export const environment: Environment = {
     production: true,
-    API_URL: 'https://sel2-2.ugent.be:2002/'
+    API_URL: 'https://sel2-2.ugent.be:2002'
 }

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,4 +1,4 @@
-export interface Environment {
+interface Environment {
     production: boolean;
     API_URL: string;
 }


### PR DESCRIPTION
- While deploying the server I noticed that for the API url in production there was an extra `/` at the end that shouldn't be there.
- In the `angular.json` `nl` was added so it will also build the application with the `nl` locale.
- When building for production the *builder* can't see `environment.ts` so the interface should be declared twice.
- I noticed that the DB on the server doesn't automatically restart when the server is restarted, I updated this in the compose file.
- On the server I configured *NGINX* to route to the correct locale subfolders

closes #370 