### PR TITLE
[Frontend] - #388 - replace sessionStorage by localStorage

### DIFF
--- a/frontend/src/app/services/authentication.service.ts
+++ b/frontend/src/app/services/authentication.service.ts
@@ -84,20 +84,20 @@ export class AuthenticationService {
       });
   }
 
-  storeToken = (token: string): void => sessionStorage.setItem('AuthenticationToken', token);
-  retrieveToken = (): string | null => sessionStorage.getItem('AuthenticationToken');
-  removeToken = (): void => sessionStorage.removeItem('AuthenticationToken');
+  storeToken = (token: string): void => localStorage.setItem('AuthenticationToken', token);
+  retrieveToken = (): string | null => localStorage.getItem('AuthenticationToken');
+  removeToken = (): void => localStorage.removeItem('AuthenticationToken');
 
-  storeRefreshToken = (refreshToken: string): void => sessionStorage.setItem('RefreshToken', refreshToken);
-  retrieveRefreshToken = (): string | null => sessionStorage.getItem('RefreshToken');
-  removeRefreshToken = (): void => sessionStorage.removeItem('RefreshToken');
+  storeRefreshToken = (refreshToken: string): void => localStorage.setItem('RefreshToken', refreshToken);
+  retrieveRefreshToken = (): string | null => localStorage.getItem('RefreshToken');
+  removeRefreshToken = (): void => localStorage.removeItem('RefreshToken');
 
-  storeUserId = (userId: string): void => sessionStorage.setItem('UserId', userId);
-  retrieveUserId = (): string | null => sessionStorage.getItem('UserId');
-  removeUserId = (): void => sessionStorage.removeItem('UserId');
+  storeUserId = (userId: string): void => localStorage.setItem('UserId', userId);
+  retrieveUserId = (): string | null => localStorage.getItem('UserId');
+  removeUserId = (): void => localStorage.removeItem('UserId');
 
-  storeUserType = (userType: UserType): void => sessionStorage.setItem('UserType', userType);
-  retrieveUserType = (): UserType | null => sessionStorage.getItem('UserType') as UserType;
-  removeUserType = (): void => sessionStorage.removeItem('UserType');
+  storeUserType = (userType: UserType): void => localStorage.setItem('UserType', userType);
+  retrieveUserType = (): UserType | null => localStorage.getItem('UserType') as UserType;
+  removeUserType = (): void => localStorage.removeItem('UserType');
 
 }


### PR DESCRIPTION
## Related Issues

- closes #388 

## Description

Because of the [different scope](http://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) of `localStorage` vs `sessionStorage`, @brentjan thought it would be a good idea to switch to the first.

This PR simply does that and nothing more