### PR TITLE
[Backend] - Removed await datasource promise lines

### DIFF
--- a/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceAssignmentTypeORM.ts
+++ b/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceAssignmentTypeORM.ts
@@ -31,10 +31,12 @@ export class DatasourceAssignmentTypeORM extends DatasourceTypeORM {
     }
 
     public async getAssignmentById(id: string): Promise<Assignment | null> {
-        const assignmentModel: AssignmentTypeORM | null = await this.datasource.getRepository(AssignmentTypeORM).findOne({
-            where: { id: id },
-            relations: ["class"],
-        });
+        const assignmentModel: AssignmentTypeORM | null = await this.datasource
+            .getRepository(AssignmentTypeORM)
+            .findOne({
+                where: { id: id },
+                relations: ["class"],
+            });
 
         if (assignmentModel !== null) {
             return assignmentModel.toAssignmentEntity();

--- a/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceClassTypeORM.ts
+++ b/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceClassTypeORM.ts
@@ -18,10 +18,12 @@ export class DatasourceClassTypeORM extends DatasourceTypeORM {
 
         classModel = await this.datasource.getRepository(ClassTypeORM).save(classModel);
 
-        let teacherOfClassModel: TeacherOfClassTypeORM = await this.datasource.getRepository(TeacherOfClassTypeORM).create({
-            teacher: { id: newClass.teacherId },
-            class: { id: classModel.id },
-        });
+        let teacherOfClassModel: TeacherOfClassTypeORM = await this.datasource
+            .getRepository(TeacherOfClassTypeORM)
+            .create({
+                teacher: { id: newClass.teacherId },
+                class: { id: classModel.id },
+            });
 
         teacherOfClassModel = await this.datasource.getRepository(TeacherOfClassTypeORM).save(teacherOfClassModel);
 
@@ -44,7 +46,6 @@ export class DatasourceClassTypeORM extends DatasourceTypeORM {
     }
 
     public async getClassByName(name: string): Promise<Class | null> {
-
         const classModel: ClassTypeORM | null = await this.datasource
             .getRepository(ClassTypeORM)
             .findOne({ where: { name: name } });
@@ -60,7 +61,6 @@ export class DatasourceClassTypeORM extends DatasourceTypeORM {
     }
 
     public async getAllClasses(): Promise<Class[]> {
-
         const classModels: ClassTypeORM[] = await this.datasource.getRepository(ClassTypeORM).find();
 
         return Promise.all(
@@ -75,7 +75,6 @@ export class DatasourceClassTypeORM extends DatasourceTypeORM {
     }
 
     public async deleteClassById(id: string): Promise<void> {
-
         await this.datasource.getRepository(ClassTypeORM).delete(id);
     }
 
@@ -96,10 +95,12 @@ export class DatasourceClassTypeORM extends DatasourceTypeORM {
 
         if (student) {
             // Get the student's classes
-            const studentClasses: StudentOfClassTypeORM[] = await this.datasource.getRepository(StudentOfClassTypeORM).find({
-                where: { student: { id: id } },
-                relations: ["class", "student"],
-            });
+            const studentClasses: StudentOfClassTypeORM[] = await this.datasource
+                .getRepository(StudentOfClassTypeORM)
+                .find({
+                    where: { student: { id: id } },
+                    relations: ["class", "student"],
+                });
             return Promise.all(
                 studentClasses.map(async studentOfClass => {
                     const teacherOfClass = await this.datasource.getRepository(TeacherOfClassTypeORM).findOne({
@@ -110,10 +111,12 @@ export class DatasourceClassTypeORM extends DatasourceTypeORM {
             );
         } else {
             // Get the teacher's classes
-            const teacherClasses: TeacherOfClassTypeORM[] = await this.datasource.getRepository(TeacherOfClassTypeORM).find({
-                where: { teacher: { id: id } },
-                relations: ["class", "teacher"],
-            });
+            const teacherClasses: TeacherOfClassTypeORM[] = await this.datasource
+                .getRepository(TeacherOfClassTypeORM)
+                .find({
+                    where: { teacher: { id: id } },
+                    relations: ["class", "teacher"],
+                });
             return Promise.all(
                 teacherClasses.map(teacherOfClass => {
                     return teacherOfClass.class.toClassEntity(teacherOfClass.teacher.id);

--- a/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceGroupTypeORM.ts
+++ b/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceGroupTypeORM.ts
@@ -53,10 +53,12 @@ export class DatasourceGroupTypeORM extends DatasourceTypeORM {
         }
 
         // Fetch all students in that group
-        const studentOfGroups: StudentOfGroupTypeORM[] = await this.datasource.getRepository(StudentOfGroupTypeORM).find({
-            where: { group: groupModel },
-            relations: ["student", "student.student"], // student.student fetches UserTypeORM
-        });
+        const studentOfGroups: StudentOfGroupTypeORM[] = await this.datasource
+            .getRepository(StudentOfGroupTypeORM)
+            .find({
+                where: { group: groupModel },
+                relations: ["student", "student.student"], // student.student fetches UserTypeORM
+            });
 
         // Extract StudentTypeORM models
         const studentModels: StudentTypeORM[] = studentOfGroups.map(entry => entry.student);

--- a/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceJoinRequestTypeORM.ts
+++ b/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceJoinRequestTypeORM.ts
@@ -44,7 +44,6 @@ export class DatasourceJoinRequestTypeORM extends DatasourceTypeORM {
     }
 
     public async getJoinRequestById(id: string): Promise<JoinRequest | null> {
-
         const joinRequest: JoinRequestTypeORM | null = await this.datasource.getRepository(JoinRequestTypeORM).findOne({
             where: { id: id },
             relations: ["requester", "class"],
@@ -54,7 +53,6 @@ export class DatasourceJoinRequestTypeORM extends DatasourceTypeORM {
     }
 
     public async getJoinRequestByRequesterId(requesterId: string): Promise<JoinRequest[]> {
-
         const joinRequests: JoinRequestTypeORM[] = await this.datasource.getRepository(JoinRequestTypeORM).find({
             where: { requester: { id: requesterId } },
             relations: ["requester", "class"],
@@ -64,7 +62,6 @@ export class DatasourceJoinRequestTypeORM extends DatasourceTypeORM {
     }
 
     public async getJoinRequestByClassId(classId: string): Promise<JoinRequest[]> {
-
         const joinRequests: JoinRequestTypeORM[] = await this.datasource.getRepository(JoinRequestTypeORM).find({
             where: { class: { id: classId } },
             relations: ["requester", "class"],

--- a/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceMessageTypeORM.ts
+++ b/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceMessageTypeORM.ts
@@ -7,7 +7,6 @@ import { UserTypeORM } from "../../data_models/userTypeorm";
 
 export class DatasourceMessageTypeORM extends DatasourceTypeORM {
     public async createMessage(message: Message): Promise<Message> {
-
         const userRepository = this.datasource.getRepository(UserTypeORM);
         const threadRepository = this.datasource.getRepository(QuestionThreadTypeORM);
         const messageRepository = this.datasource.getRepository(MessageTypeORM);
@@ -35,7 +34,6 @@ export class DatasourceMessageTypeORM extends DatasourceTypeORM {
     }
 
     public async getMessageById(id: string): Promise<Message | null> {
-
         const messageModel: MessageTypeORM | null = await this.datasource
             .getRepository(MessageTypeORM)
             .findOne({ where: { id: id } });
@@ -49,7 +47,6 @@ export class DatasourceMessageTypeORM extends DatasourceTypeORM {
     }
 
     public async updateMessage(message: Message): Promise<Message> {
-
         if (!message.id) {
             throw new Error("Message id is required to update a message");
         }

--- a/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceStudentTypeORM.ts
+++ b/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceStudentTypeORM.ts
@@ -11,7 +11,6 @@ import { UserTypeORM } from "../../data_models/userTypeorm";
 
 export class DatasourceStudentTypeORM extends DatasourceTypeORM {
     public async createStudent(student: Student): Promise<Student> {
-
         const userModel: UserTypeORM = await this.datasource
             .getRepository(UserTypeORM)
             .save(UserTypeORM.createUserTypeORM(student));
@@ -24,7 +23,6 @@ export class DatasourceStudentTypeORM extends DatasourceTypeORM {
     }
 
     public async getStudentById(id: string): Promise<Student | null> {
-
         const studentModel: StudentTypeORM | null = await this.datasource.getRepository(StudentTypeORM).findOne({
             where: { id: id },
             relations: ["student"],
@@ -41,7 +39,6 @@ export class DatasourceStudentTypeORM extends DatasourceTypeORM {
     }
 
     public async getStudentByEmail(email: string): Promise<Student | null> {
-
         const userModel: UserTypeORM | null = await this.datasource
             .getRepository(UserTypeORM)
             .findOne({ where: { email: email } });
@@ -59,7 +56,6 @@ export class DatasourceStudentTypeORM extends DatasourceTypeORM {
     }
 
     public async getStudentByFirstName(first_name: string): Promise<Student | null> {
-
         const userModel: UserTypeORM | null = await this.datasource
             .getRepository(UserTypeORM)
             .findOne({ where: { first_name: first_name } });
@@ -77,7 +73,6 @@ export class DatasourceStudentTypeORM extends DatasourceTypeORM {
     }
 
     public async getStudentByLastName(last_name: string): Promise<Student | null> {
-
         const userModel: UserTypeORM | null = await this.datasource
             .getRepository(UserTypeORM)
             .findOne({ where: { last_name: last_name } });
@@ -95,7 +90,6 @@ export class DatasourceStudentTypeORM extends DatasourceTypeORM {
     }
 
     public async getAllStudents(): Promise<Student[]> {
-
         const studentModels: StudentTypeORM[] = await this.datasource
             .getRepository(StudentTypeORM)
             .find({ relations: ["student"] });
@@ -104,7 +98,6 @@ export class DatasourceStudentTypeORM extends DatasourceTypeORM {
     }
 
     public async updateStudent(student: Student): Promise<Student> {
-
         const studentModel: StudentTypeORM | null = await this.datasource.getRepository(StudentTypeORM).findOne({
             where: { id: student.id },
             relations: ["student"],
@@ -122,7 +115,6 @@ export class DatasourceStudentTypeORM extends DatasourceTypeORM {
     }
 
     public async deleteStudentWithId(id: string): Promise<void> {
-
         const studentModel: StudentTypeORM | null = await this.datasource.getRepository(StudentTypeORM).findOne({
             where: { id: id },
             relations: ["student"],
@@ -142,7 +134,6 @@ export class DatasourceStudentTypeORM extends DatasourceTypeORM {
     }
 
     public async removeStudentFromClass(studentId: string, classId: string): Promise<void> {
-
         const classModel: ClassTypeORM | null = await this.datasource
             .getRepository(ClassTypeORM)
             .findOne({ where: { id: classId } });
@@ -165,7 +156,6 @@ export class DatasourceStudentTypeORM extends DatasourceTypeORM {
     }
 
     public async removeStudentFromGroup(studentId: string, groupId: string): Promise<void> {
-
         const groupModel: GroupTypeORM | null = await this.datasource
             .getRepository(GroupTypeORM)
             .findOne({ where: { id: groupId } });
@@ -188,7 +178,6 @@ export class DatasourceStudentTypeORM extends DatasourceTypeORM {
     }
 
     public async assignStudentToGroup(studentId: string, groupId: string): Promise<void> {
-
         const groupModel: GroupTypeORM | null = await this.datasource
             .getRepository(GroupTypeORM)
             .findOne({ where: { id: groupId } });
@@ -211,7 +200,6 @@ export class DatasourceStudentTypeORM extends DatasourceTypeORM {
     }
 
     public async getClassStudents(classId: string): Promise<Student[]> {
-
         const classJoinResult = await this.datasource
             .getRepository(StudentOfClassTypeORM)
             .createQueryBuilder("studentOfClass")
@@ -227,11 +215,12 @@ export class DatasourceStudentTypeORM extends DatasourceTypeORM {
     }
 
     public async getAssignmentStudents(assignmentId: string): Promise<Student[]> {
-
-        const assignmentModel: AssignmentTypeORM | null = await this.datasource.getRepository(AssignmentTypeORM).findOne({
-            where: { id: assignmentId },
-            relations: ["class"],
-        });
+        const assignmentModel: AssignmentTypeORM | null = await this.datasource
+            .getRepository(AssignmentTypeORM)
+            .findOne({
+                where: { id: assignmentId },
+                relations: ["class"],
+            });
 
         console.log(assignmentModel);
 

--- a/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceSubmissionTypeORM.ts
+++ b/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceSubmissionTypeORM.ts
@@ -7,7 +7,6 @@ import { SubmissionTypeORM } from "../../data_models/submissionTypeorm";
 
 export class DatasourceSubmissionTypeORM extends DatasourceTypeORM {
     public async create(submission: Submission): Promise<string> {
-
         const assignmentRepository = this.datasource.getRepository(AssignmentTypeORM);
         const studentRepository = this.datasource.getRepository(StudentTypeORM);
         const submissionRepository = this.datasource.getRepository(SubmissionTypeORM);
@@ -42,10 +41,11 @@ export class DatasourceSubmissionTypeORM extends DatasourceTypeORM {
     }
 
     public async getById(id: string): Promise<Submission | null> {
-
-        const submissionModel: SubmissionTypeORM | null = await this.datasource.getRepository(SubmissionTypeORM).findOne({
-            where: { id: id },
-        });
+        const submissionModel: SubmissionTypeORM | null = await this.datasource
+            .getRepository(SubmissionTypeORM)
+            .findOne({
+                where: { id: id },
+            });
 
         if (submissionModel) {
             return submissionModel.toEntity();
@@ -54,7 +54,6 @@ export class DatasourceSubmissionTypeORM extends DatasourceTypeORM {
     }
 
     public async update(submission: Submission): Promise<Submission> {
-
         const submissionRepository = this.datasource.getRepository(SubmissionTypeORM);
         const submissionModel: SubmissionTypeORM | null = await submissionRepository.findOne({
             where: { id: submission.id },
@@ -87,7 +86,6 @@ export class DatasourceSubmissionTypeORM extends DatasourceTypeORM {
         assignmentId: string,
         learningObjectId: string,
     ): Promise<Submission[]> {
-
         const studentRepository = this.datasource.getRepository(StudentTypeORM);
         const assignmentRepository = this.datasource.getRepository(AssignmentTypeORM);
         const submissionRepository = this.datasource.getRepository(SubmissionTypeORM);
@@ -116,7 +114,6 @@ export class DatasourceSubmissionTypeORM extends DatasourceTypeORM {
     }
 
     public async getByStudentId(studentId: string): Promise<Submission[]> {
-
         const studentRepository = this.datasource.getRepository(StudentTypeORM);
         const submissionRepository = this.datasource.getRepository(SubmissionTypeORM);
         // First get the student

--- a/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceTeacherTypeORM.ts
+++ b/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceTeacherTypeORM.ts
@@ -7,7 +7,6 @@ import { UserTypeORM } from "../../data_models/userTypeorm";
 
 export class DatasourceTeacherTypeORM extends DatasourceTypeORM {
     public async createTeacher(teacher: Teacher): Promise<Teacher> {
-
         const userModel: UserTypeORM = await this.datasource
             .getRepository(UserTypeORM)
             .save(UserTypeORM.createUserTypeORM(teacher));
@@ -20,7 +19,6 @@ export class DatasourceTeacherTypeORM extends DatasourceTypeORM {
     }
 
     public async getTeacherById(id: string): Promise<Teacher | null> {
-
         const teacherModel: TeacherTypeORM | null = await this.datasource.getRepository(TeacherTypeORM).findOne({
             where: { id: id },
             relations: ["teacher"],
@@ -35,7 +33,6 @@ export class DatasourceTeacherTypeORM extends DatasourceTypeORM {
     }
 
     public async getTeacherByEmail(email: string): Promise<Teacher | null> {
-
         const userModel: UserTypeORM | null = await this.datasource
             .getRepository(UserTypeORM)
             .findOne({ where: { email: email } });
@@ -53,7 +50,6 @@ export class DatasourceTeacherTypeORM extends DatasourceTypeORM {
     }
 
     public async getTeacherByFirstName(first_name: string): Promise<Teacher | null> {
-
         const userModel: UserTypeORM | null = await this.datasource
             .getRepository(UserTypeORM)
             .findOne({ where: { first_name: first_name } });
@@ -71,7 +67,6 @@ export class DatasourceTeacherTypeORM extends DatasourceTypeORM {
     }
 
     public async getTeacherByLastName(last_name: string): Promise<Teacher | null> {
-
         const userModel: UserTypeORM | null = await this.datasource
             .getRepository(UserTypeORM)
             .findOne({ where: { last_name: last_name } });
@@ -89,7 +84,6 @@ export class DatasourceTeacherTypeORM extends DatasourceTypeORM {
     }
 
     public async getAllTeachers(): Promise<Teacher[]> {
-
         const teacherModels: TeacherTypeORM[] = await this.datasource
             .getRepository(TeacherTypeORM)
             .find({ relations: ["teacher"] });
@@ -98,7 +92,6 @@ export class DatasourceTeacherTypeORM extends DatasourceTypeORM {
     }
 
     public async updateTeacher(teacher: Teacher): Promise<Teacher> {
-
         await this.datasource.getRepository(UserTypeORM).update(teacher.id!, UserTypeORM.createUserTypeORM(teacher));
 
         // For now, there is no need to update the Teacher table
@@ -107,7 +100,6 @@ export class DatasourceTeacherTypeORM extends DatasourceTypeORM {
     }
 
     public async deleteTeacherWithId(id: string): Promise<void> {
-
         const teacherModel: TeacherTypeORM | null = await this.datasource.getRepository(TeacherTypeORM).findOne({
             where: { id: id },
             relations: ["teacher"],
@@ -122,7 +114,6 @@ export class DatasourceTeacherTypeORM extends DatasourceTypeORM {
     }
 
     public async deleteTeacherFromClass(teacherId: string, classId: string): Promise<void> {
-
         await this.datasource
             .createQueryBuilder()
             .delete()
@@ -132,7 +123,6 @@ export class DatasourceTeacherTypeORM extends DatasourceTypeORM {
     }
 
     public async getClassTeachers(classId: string): Promise<Teacher[]> {
-
         const teacherOfClassModels: TeacherOfClassTypeORM[] = await this.datasource
             .getRepository(TeacherOfClassTypeORM)
             .find({

--- a/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceThreadTypeORM.ts
+++ b/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceThreadTypeORM.ts
@@ -8,7 +8,6 @@ import { StudentTypeORM } from "../../data_models/studentTypeorm";
 
 export class DatasourceThreadTypeORM extends DatasourceTypeORM {
     public async create(thread: QuestionThread): Promise<QuestionThread> {
-
         const userRepository = this.datasource.getRepository(StudentTypeORM);
         const threadRepository = this.datasource.getRepository(QuestionThreadTypeORM);
         const assignmentRepository = this.datasource.getRepository(AssignmentTypeORM);
@@ -36,7 +35,6 @@ export class DatasourceThreadTypeORM extends DatasourceTypeORM {
     }
 
     public async getById(id: string): Promise<QuestionThread | null> {
-
         const threadRepository = this.datasource.getRepository(QuestionThreadTypeORM);
         const messageRepository = this.datasource.getRepository(MessageTypeORM);
 
@@ -53,7 +51,6 @@ export class DatasourceThreadTypeORM extends DatasourceTypeORM {
     }
 
     public async update(thread: QuestionThread): Promise<QuestionThread> {
-
         const threadRepository = this.datasource.getRepository(QuestionThreadTypeORM);
         const messageRepository = this.datasource.getRepository(MessageTypeORM);
 
@@ -82,7 +79,6 @@ export class DatasourceThreadTypeORM extends DatasourceTypeORM {
     }
 
     public async delete(thread: QuestionThread): Promise<void> {
-
         const messageRepository = this.datasource.getRepository(MessageTypeORM);
         const threadRepository = this.datasource.getRepository(QuestionThreadTypeORM);
 
@@ -100,7 +96,6 @@ export class DatasourceThreadTypeORM extends DatasourceTypeORM {
     }
 
     public async updateQuestionThread(id: string, updatedThread: Partial<QuestionThread>): Promise<QuestionThread> {
-
         await this.datasource
             .getRepository(QuestionThreadTypeORM)
             .update(id, QuestionThreadTypeORM.toPartial(updatedThread));
@@ -114,17 +109,17 @@ export class DatasourceThreadTypeORM extends DatasourceTypeORM {
     }
 
     public async deleteQuestionThread(id: string): Promise<void> {
-
         // TODO: should throw error when it doesn't exist
         await this.datasource.getRepository(QuestionThreadTypeORM).delete(id);
     }
 
     public async getQuestionThreadsByAssignmentId(assignmentId: string): Promise<QuestionThread[]> {
-
-        const questionThreads: QuestionThreadTypeORM[] = await this.datasource.getRepository(QuestionThreadTypeORM).find({
-            where: { assignment: { id: assignmentId } },
-            relations: ["student", "assignment"],
-        });
+        const questionThreads: QuestionThreadTypeORM[] = await this.datasource
+            .getRepository(QuestionThreadTypeORM)
+            .find({
+                where: { assignment: { id: assignmentId } },
+                relations: ["student", "assignment"],
+            });
 
         if (!questionThreads) {
             throw new EntityNotFoundError(`No threads found for assignment with id: ${assignmentId}`);
@@ -144,11 +139,12 @@ export class DatasourceThreadTypeORM extends DatasourceTypeORM {
     }
 
     public async getQuestionThreadsByCreatorId(createrId: string): Promise<QuestionThread[]> {
-
-        const questionThreads: QuestionThreadTypeORM[] = await this.datasource.getRepository(QuestionThreadTypeORM).find({
-            where: { student: { id: createrId } },
-            relations: ["student", "assignment"],
-        });
+        const questionThreads: QuestionThreadTypeORM[] = await this.datasource
+            .getRepository(QuestionThreadTypeORM)
+            .find({
+                where: { student: { id: createrId } },
+                relations: ["student", "assignment"],
+            });
 
         const threads = await Promise.all(
             questionThreads.map(async questionThread => {

--- a/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceTypeORM.ts
+++ b/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceTypeORM.ts
@@ -24,7 +24,7 @@ export class DatasourceTypeORM implements IDatasource {
     );
 
     private static _datasource: DataSource | null = null; // Use a single DataSource for all instances of this class and its children
-  
+
     private static async initialize() {
         // sets the _datasource field if it's not set yet
         if (!this._datasource) {
@@ -32,14 +32,13 @@ export class DatasourceTypeORM implements IDatasource {
             this._datasource = await this._datasourcePromise;
         }
     }
-  
+
     protected get datasource(): DataSource {
         // gets the static _datasource field. If it's not initialized yet, it waits for the initialization
-        DatasourceTypeORM.initialize()
-        while(!DatasourceTypeORM._datasource){
+        DatasourceTypeORM.initialize();
+        while (!DatasourceTypeORM._datasource) {
             // Wait until the async initialize function has finished
         }
         return DatasourceTypeORM._datasource;
     }
-
 }


### PR DESCRIPTION
Now in the specific data sources, the line 
```js
const datasource = await DatasourceTypeORM.datasourcePromise;
```
is not needed anymore.
Now there can just be used:
```js
this.datasource.getRepository(...);
```
This was achieved by making a smart getter in DatasourceTypeORM that waits in a while loop until the private _datasource field is not null:
```js
private static _datasource: DataSource | null = null; // Use a single DataSource for all instances of this class and its children

    private static async initialize() {
        // sets the _datasource field if it's not set yet
        if (!this._datasource) {
            // Does this by awaiting the datasourcePromise
            this._datasource = await this._datasourcePromise;
        }
    }

    protected get datasource(): DataSource {
        // gets the static _datasource field. If it's not initialized yet, it waits for the initialization
        DatasourceTypeORM.initialize();
        while (!DatasourceTypeORM._datasource) {
            // Wait until the async initialize function has finished
        }
        return DatasourceTypeORM._datasource;
    }
```
This was done on a separate branch because there are already a lot of changes on [317](https://github.com/SELab-2/Dwengo-2/pull/323), and im not sure if this will work as intended. 