### PR TITLE
[Frontend] - force reload on class pages after creating a new class

### DIFF
--- a/frontend/src/app/components/create-class/create-class.component.ts
+++ b/frontend/src/app/components/create-class/create-class.component.ts
@@ -10,6 +10,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatCard, MatCardContent } from '@angular/material/card'
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { AuthenticationService } from '../../services/authentication.service';
+import { Router } from '@angular/router';
 
 
 @Component({
@@ -41,6 +42,7 @@ export class CreateClassComponent {
   public createForm: FormGroup;
   
   public constructor(
+    private router: Router,
     private formBuilder: FormBuilder,
     private classesService: ClassesService,
     private authService: AuthenticationService
@@ -64,6 +66,9 @@ export class CreateClassComponent {
       idObservable.pipe().subscribe(() => 
         this.openSnackBar(this.createSuccesMessage)
       );
+
+      // force a refresh of the page to show the updated list of classes
+      location.reload();
     } else {
       this.openSnackBar(this.errorMessage);
     }


### PR DESCRIPTION
## Description

By using `location.reload()` after successfully creating a class, we can close the creation component and show the new class.

## Recording

https://github.com/user-attachments/assets/4418fe14-71ff-4076-8e8d-07345c9e9277

