### PR TITLE
[Backend] - fix bug create join request

### DIFF
--- a/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceJoinRequestTypeORM.ts
+++ b/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceJoinRequestTypeORM.ts
@@ -53,8 +53,11 @@ export class DatasourceJoinRequestTypeORM extends DatasourceTypeORM {
             where: { id: id },
             relations: ["requester", "class"],
         });
+        if (!joinRequest) {
+            return null;
+        }
 
-        return joinRequest?.toJoinRequestEntity() || null;
+        return joinRequest.toJoinRequestEntity();
     }
 
     public async getJoinRequestByRequesterId(requesterId: string): Promise<JoinRequest[]> {


### PR DESCRIPTION
I found the potential origin of the bug in create join request.

In the datasource for join requests, the old code tried to match the user id with a student id or teacher id. But since user id's are currently separate from teacher id's and student id's there needed to be matched on users in the where clause, instead of id's.

`fix #408`