### PR TITLE
[Backend] - Enhancements to dwengo endpoints

### DIFF
--- a/backend/api/openapi.yml
+++ b/backend/api/openapi.yml
@@ -712,6 +712,7 @@ paths:
             This parameter takes a string as a value and searches all learning paths
             for which the value occurs in the title, description, or hruid.
             (This can have an empty string as a parameter which matches all descriptions and titles)
+            If multiple words want to be searched these can be added with a '-' e.g. "robot-python-arduino".
           schema:
             type: string
         - name: language
@@ -734,6 +735,11 @@ paths:
           description: Search for descriptions containing a specific search term
           schema:
             type: string
+        - in: query
+          name: includeNodes
+          schema:
+            type: boolean
+          description: Whether or not to include the nodes of the learningPath
       responses:
         '200':
           $ref: '#/components/responses/PathSearchOK'
@@ -760,6 +766,11 @@ paths:
           schema:
             type: string
           description: The language of the learningPath
+        - in: query
+          name: includeNodes
+          schema:
+            type: boolean
+          description: Whether or not to include the nodes of the learningPath
       responses:
         '200':
           $ref: '#/components/responses/LearningPathOK'

--- a/backend/src/application/schemas/learningPathSchemas.ts
+++ b/backend/src/application/schemas/learningPathSchemas.ts
@@ -6,6 +6,12 @@ import { z } from "zod";
 
 export const getLearningPathSchema = z.object({
     id: z.string(),
+    includeNodes: z
+        .preprocess(
+            (val: unknown) => val === "true", // Everything that is not 'true' will be false
+            z.boolean(),
+        )
+        .optional(),
     language: z.string().optional(),
 });
 
@@ -15,6 +21,12 @@ export const getAllLearningPathsSchema = z.object({
     hruid: z.string().optional(),
     title: z.string().optional(),
     description: z.string().optional(),
+    includeNodes: z
+        .preprocess(
+            (val: unknown) => val === "true", // Everything that is not 'true' will be false
+            z.boolean(),
+        )
+        .optional(),
 });
 
-export const learningPathSearchParams = ["all", "language", "hruid", "title", "description"];
+export const learningPathSearchParams = ["language", "hruid", "title", "description"];

--- a/backend/src/core/entities/learningPath.ts
+++ b/backend/src/core/entities/learningPath.ts
@@ -49,7 +49,7 @@ export class LearningPath {
      *
      * @returns the learningPath object
      */
-    public toObject(): object {
+    public toObject(includeNodes: boolean): object {
         return {
             id: this._id,
             language: this._language,
@@ -62,7 +62,7 @@ export class LearningPath {
             targetAges: this._targetAges,
             minAge: this._minAge,
             maxAge: this._maxAge,
-            nodes: this._nodes.map(node => node.toObject()), // Zet elk node-object om
+            ...(includeNodes && { nodes: this._nodes.map(node => node.toObject()) }), // Zet elk node-object om
         };
     }
 
@@ -70,9 +70,10 @@ export class LearningPath {
      * Static function that maps a dwengo object for a learningPath to our entity type.
      *
      * @param object interface that defines the fields on the object data
+     * @param includeNodes boolean that indicates if the nodes should be included in the object
      * @returns a LearningPath object
      */
-    public static fromObject(object: LearningPathData): LearningPath {
+    public static fromObject(object: LearningPathData, includeNodes: boolean): LearningPath {
         return new LearningPath(
             object._id,
             object.language,
@@ -85,7 +86,7 @@ export class LearningPath {
             object.target_ages,
             object.min_age,
             object.max_age,
-            object.nodes.map((node: PathLearningObjectData) => PathLearningObject.fromObject(node)),
+            includeNodes ? object.nodes.map((node: PathLearningObjectData) => PathLearningObject.fromObject(node)) : [],
         );
     }
 }

--- a/backend/src/core/repositories/learningPathRepositoryInterface.ts
+++ b/backend/src/core/repositories/learningPathRepositoryInterface.ts
@@ -19,7 +19,7 @@ export abstract class ILearningPathRepository {
      *
      * @returns a promise that resolves to a learningPath.
      */
-    public abstract getLearningPath(hruid: string, language: string): Promise<LearningPath>;
+    public abstract getLearningPath(hruid: string, language: string, includeNodes: boolean): Promise<LearningPath>;
 
     /**
      * Function to get all available learningPath metadata with optional params
@@ -27,5 +27,5 @@ export abstract class ILearningPathRepository {
      * @param params string including the params for the query
      * @returns a promise that resolves to a list of all LearningPaths
      */
-    public abstract getLearningPaths(params: string): Promise<LearningPath[]>;
+    public abstract getLearningPaths(params: string, includeNodes: boolean): Promise<LearningPath[]>;
 }

--- a/backend/src/core/services/learningPath/getAllLearningPaths.ts
+++ b/backend/src/core/services/learningPath/getAllLearningPaths.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { getAllLearningPathsSchema, learningPathSearchParams } from "../../../application/schemas";
 import { Service } from "../../../config/service";
+import { LearningPath } from "../../entities/learningPath";
 import { ILearningPathRepository } from "../../repositories/learningPathRepositoryInterface";
 
 export type GetAllLearningPathsInput = z.infer<typeof getAllLearningPathsSchema>;
@@ -13,12 +14,15 @@ export class GetAllLearningPaths implements Service<GetAllLearningPathsInput> {
     constructor(private _learningPathRepository: ILearningPathRepository) {}
 
     /**
-     * Function that gets all learningObjects (metadata) from the Dwengo API with optional filters
+     * Function that gets all learningPaths from the Dwengo API with optional filters
      *
      * @param input containing the input following the defined zod schema.
-     * @returns an object containing an array of (metadata of) learningObjects
+     * @returns an object containing an array of learningPaths
      */
     async execute(input: GetAllLearningPathsInput): Promise<object> {
+        // When inclusion of nodes is not specified, default to false
+        const includeNodes = input.includeNodes ?? false;
+
         const params: string[] = [];
         for (const key of learningPathSearchParams) {
             // Add key-value pair to params
@@ -27,11 +31,23 @@ export class GetAllLearningPaths implements Service<GetAllLearningPathsInput> {
                 params.push(`${key}=${val}`);
             }
         }
-        // Create the params for the request
-        const paramsString: string = `${params.length !== 0 ? "?" : ""}${params.join("&")}`;
+        const learningPaths: LearningPath[] = [];
+        // Get all the learningObjects for each word in all if it exists
+        if (input.all && input.all.length > 0) {
+            const allParams: string[] = input.all.split("-").filter((val: string) => val.length > 0);
+            for (const allParam of allParams) {
+                const paramsString: string = `?all=${allParam}${params.length > 0 ? "&" : ""}${params.join("&")}`;
+                learningPaths.push(
+                    ...(await this._learningPathRepository.getLearningPaths(paramsString, includeNodes)),
+                );
+            }
+        } else {
+            const paramsString: string = `${params.length > 0 ? "?" : ""}${params.join("&")}`;
+            learningPaths.push(...(await this._learningPathRepository.getLearningPaths(paramsString, includeNodes)));
+        }
 
         return {
-            learningPaths: (await this._learningPathRepository.getLearningPaths(paramsString)).map(p => p.toObject()),
+            learningPaths: learningPaths.map((p: LearningPath) => p.toObject(includeNodes)),
         };
     }
 }

--- a/backend/src/core/services/learningPath/getLearningPath.ts
+++ b/backend/src/core/services/learningPath/getLearningPath.ts
@@ -19,6 +19,8 @@ export class GetLearningPath implements Service<GetLearningPathInput> {
      * @returns an object containing the path.
      */
     async execute(input: GetLearningPathInput): Promise<object> {
+        // When inclusion of nodes is not specified, default to false
+        const includeNodes = input.includeNodes ?? false;
         // Get the available languages of this path
         const languages: string[] = await this._learningPathRepository.getLanguages(input.id);
 
@@ -33,7 +35,7 @@ export class GetLearningPath implements Service<GetLearningPathInput> {
             }
         }
 
-        const path: LearningPath = await this._learningPathRepository.getLearningPath(input.id, language);
-        return path.toObject();
+        const path: LearningPath = await this._learningPathRepository.getLearningPath(input.id, language, includeNodes);
+        return path.toObject(includeNodes);
     }
 }

--- a/backend/src/infrastructure/dwengo_backend/data/data_sources/http/datasourceLearningPath.ts
+++ b/backend/src/infrastructure/dwengo_backend/data/data_sources/http/datasourceLearningPath.ts
@@ -7,9 +7,8 @@ export class DatasourceLearningPath extends DatasourceDwengo {
         super(host, "learningPath");
     }
 
-    public async getLearningPath(hruid: string, language: string): Promise<LearningPath> {
+    public async getLearningPath(hruid: string, language: string, includeNodes: boolean): Promise<LearningPath> {
         // Fetch from dwengo
-        console.log(`${this.host}/api/${this.learningType}/search?hruid=${hruid}`);
         const response = await fetch(`${this.host}/api/${this.learningType}/search?hruid=${hruid}`);
         if (!response.ok) {
             throw {
@@ -30,7 +29,7 @@ export class DatasourceLearningPath extends DatasourceDwengo {
             // Should not happen because language is checked beforehand, but just to be sure.
             throw { code: ErrorCode.NOT_FOUND, message: `No learningPath exists with this hruid.` } as ApiError;
         }
-        return LearningPath.fromObject(learningPathObject);
+        return LearningPath.fromObject(learningPathObject, includeNodes);
     }
 
     /**
@@ -38,7 +37,7 @@ export class DatasourceLearningPath extends DatasourceDwengo {
      *
      * @returns a promise that resolves to an array of all learningPaths from the Dwengo API.
      */
-    public async getLearningPaths(params: string): Promise<LearningPath[]> {
+    public async getLearningPaths(params: string, includeNodes: boolean): Promise<LearningPath[]> {
         const response = await fetch(`${this.host}/api/${this.learningType}/search${params}`);
         if (!response.ok) {
             throw {
@@ -47,6 +46,6 @@ export class DatasourceLearningPath extends DatasourceDwengo {
             } as ApiError;
         }
         // Map all objects to a LearningPath
-        return (await response.json()).map((o: LearningPathData) => LearningPath.fromObject(o));
+        return (await response.json()).map((o: LearningPathData) => LearningPath.fromObject(o, includeNodes));
     }
 }

--- a/backend/src/infrastructure/repositories/learningPathRepository.ts
+++ b/backend/src/infrastructure/repositories/learningPathRepository.ts
@@ -8,10 +8,10 @@ export class LearningPathRepository implements ILearningPathRepository {
     public getLanguages(hruid: string): Promise<string[]> {
         return this.datasource.getLanguages(hruid);
     }
-    public getLearningPath(hruid: string, language: string): Promise<LearningPath> {
-        return this.datasource.getLearningPath(hruid, language);
+    public getLearningPath(hruid: string, language: string, includeNodes: boolean): Promise<LearningPath> {
+        return this.datasource.getLearningPath(hruid, language, includeNodes);
     }
-    public getLearningPaths(params: string): Promise<LearningPath[]> {
-        return this.datasource.getLearningPaths(params);
+    public getLearningPaths(params: string, includeNodes: boolean): Promise<LearningPath[]> {
+        return this.datasource.getLearningPaths(params, includeNodes);
     }
 }


### PR DESCRIPTION
- Added some improvements that @lennertdr suggested
  - You can now add an optional queryparam **includeNodes**, you can use this when the info of the nodes inside of a learningPath is not needed
  - When searcing for learningPaths you can now search for multiple keywords at once, by joining
  the words together with a '-'.
    - *E.g.* `http://localhost:3001/learningPath?all=biology-climate-animals`

closes #453 