### PR TITLE
[Frontend] - Create group component update

### DIFF
--- a/frontend/src/app/components/create-group/create-group.component.html
+++ b/frontend/src/app/components/create-group/create-group.component.html
@@ -7,7 +7,16 @@
             Here you can divide the members of your class into groups. 
             Drag a member into an existing group or onto the new group.
         </p>
-        <h2>Members</h2>
+        <span style="display: flex; align-items: center;">
+            <h2>Members</h2>
+            <button 
+                mat-raised-button 
+                (click)="partitionMembers()" 
+                id="assign-all-button"
+                style="margin-left: 75px;">
+                Assign all
+            </button>
+        </span>
         <div
             id="members-list"
             class="members-list"

--- a/frontend/src/app/components/create-group/create-group.component.html
+++ b/frontend/src/app/components/create-group/create-group.component.html
@@ -2,19 +2,19 @@
 <div class="create-group">
     <!-- Members Section -->
     <div class="members-container">
-        <h1>Create groups</h1>
+        <h1 i18n>Create groups</h1>
         <p i18n>
             Here you can divide the members of your class into groups. 
             Drag a member into an existing group or onto the new group.
         </p>
         <span style="display: flex; align-items: center;">
-            <h2>Members</h2>
+            <h2 i18n>Members</h2>
             <button 
                 mat-raised-button 
                 (click)="partitionMembers()" 
                 id="assign-all-button"
                 style="margin-left: 75px;">
-                Assign all
+                <p>Assign all</p>
             </button>
         </span>
         <div
@@ -33,7 +33,7 @@
         <br>
         <button mat-fab extended (click)="createGroups()" id="create-group-button">
             <mat-icon>add</mat-icon>
-            Create groups
+            <p i18n>Create groups</p>
         </button>
     </div>
 

--- a/frontend/src/app/components/create-group/create-group.component.spec.ts
+++ b/frontend/src/app/components/create-group/create-group.component.spec.ts
@@ -79,4 +79,9 @@ describe('CreateGroupComponent', () => {
         expect(newGroupDroplist).toBeTruthy();
     });
 
+    it('should have an assign all button', () => {
+        const assignAllButton = fixture.nativeElement.querySelector('button[id="assign-all-button"]');
+        expect(assignAllButton).toBeTruthy();
+    });
+
 });

--- a/frontend/src/app/components/create-group/create-group.component.ts
+++ b/frontend/src/app/components/create-group/create-group.component.ts
@@ -115,11 +115,13 @@ export class CreateGroupComponent {
     if (this.members.length > 0) {
       this.openSnackBar("There are still members not in a group.");
     } else {
-      this.groupService.createGroups(this.groups, this.assignmentId!)
+      const nonEmptyGroups = this.groups.filter(group => group.length > 0);
+
+      this.groupService.createGroups(nonEmptyGroups, this.assignmentId!)
         .subscribe((response) => {
           if(response) {
             this.openSnackBar("Groups created successfully.");
-            // TODO: redirects? empty lists?
+            // TODO: wait until create assignment is done #338
           } else {
             this.openSnackBar("Failed to create groups.");
           }
@@ -140,6 +142,13 @@ export class CreateGroupComponent {
    */
   public get emptyGroup(): User[] {
     return [];
+  }
+
+  public partitionMembers(): void {
+    this.members.forEach((member) => {
+      this._groups.push([member]);
+    });
+    this.members = [];
   }
 
   private openSnackBar(message: string, action: string="Ok") {


### PR DESCRIPTION
I updated the create group component so it implements the updates requested in #524 which can be closed.

This component now has a button that assigns each member of the class to an individual group.
[Screencast from 2025-05-04 20-03-36.webm](https://github.com/user-attachments/assets/b37913b1-0925-4159-8223-94e0845624cd)

Empty groups aren't send to the API during creation.