### PR TITLE
[Database] - Connection pooling poolSize parameter

### DIFF
--- a/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceTypeORM.ts
+++ b/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceTypeORM.ts
@@ -18,8 +18,9 @@ export class DatasourceTypeORM implements IDatasource {
             true,
             false,
             host,
+            false,
+            15, // number of connections in the pool
         );
-
     // Promise of the TypeORM DataSource object
     // This object is needed for the repositories to be able to ask queries.
     protected static datasourcePromise: Promise<DataSource> = DatasourceTypeORMSingleton.getInstance(

--- a/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceTypeORMConnectionSettings.ts
+++ b/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceTypeORMConnectionSettings.ts
@@ -14,6 +14,7 @@ export class DatasourceTypeORMConnectionSettings {
         private synchronize: boolean,
         private logging: boolean,
         private dropschema: boolean,
+        private poolSize: number,
 
         // Next any[] is not possible to replace with a more specific type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -92,6 +93,14 @@ export class DatasourceTypeORMConnectionSettings {
         this.dropschema = dropschema;
     }
 
+    public getPoolSize(): number {
+        return this.poolSize;
+    }
+
+    public setPoolSize(poolSize: number): void {
+        this.poolSize = poolSize;
+    }
+
     // Next any[] is not possible to replace with a more specific type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     public getEntities(): any[] {
@@ -117,6 +126,7 @@ export class DatasourceTypeORMConnectionSettings {
             synchronize: this.synchronize,
             logging: this.logging,
             dropschema: this.dropschema,
+            poolSize: this.poolSize,
             entities: this.entities,
         };
     }

--- a/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceTypeORMConnectionSettingsFactory.ts
+++ b/backend/src/infrastructure/database/data/data_sources/typeorm/datasourceTypeORMConnectionSettingsFactory.ts
@@ -31,6 +31,7 @@ export class DatasourceTypeORMConnectionSettingsFactory {
      * @param logging Enable logging (recommended)
      * @param host Hostname
      * @param dropschema Drop the schema after closing the connection (never set this to true in production)
+     * @param poolSize Number of open connections in the connection pool
      * @param entities The entities of the database (our data models)
      * @returns A new DatasourceTypeORMConnectionSettings object with the given configurations
      */
@@ -44,6 +45,7 @@ export class DatasourceTypeORMConnectionSettingsFactory {
         logging: boolean = false,
         host: string = "database",
         dropschema: boolean = false, // Never set this to true in production
+        poolSize: number = 15,
 
         // Next any[] is not possible to replace with a more specific type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -73,6 +75,7 @@ export class DatasourceTypeORMConnectionSettingsFactory {
             synchronize,
             logging,
             dropschema,
+            poolSize,
             entities,
         );
     }


### PR DESCRIPTION
TypeORM already does connection pooling, so I did not need to change a lot.

There is already a parameter for setting the connection `poolSize` in the `BaseDataSourceOptions` in typeORM, so I just updated our `DataSourceConnectionSettings` and so, to support that parameter too.