### PR TITLE
[Backend] - Fix patch submissions and bug fix getusersubmissions endpoint

### DIFF
--- a/backend/api/openapi.yml
+++ b/backend/api/openapi.yml
@@ -1831,6 +1831,26 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+    patch:
+      tags:
+        - submissions
+      summary: Update submission
+      description: Change status type, from not_accepted to accepted and vice versa, of a submission using its unique identifier.
+      operationId: updateSubmission
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "204":
+          $ref: "#/components/responses/NoContent"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
     delete:
       tags:
         - submissions
@@ -1883,7 +1903,7 @@ paths:
           name: idParent
           required: true
           schema:
-            type: string
+            type: stringj
             format: uuid
         - $ref: "#/components/parameters/PageParam"
         - $ref: "#/components/parameters/PageSizeParam"
@@ -1894,9 +1914,9 @@ paths:
             type: string
             format: uuid
         - in: query
-          name: learningObjectId
+          name: taskId
           description: |
-            Optional param to get the user's submission for a certain step in an assignment.
+            Optional param to get the user's submission for a certain task in an assignment.
             assignmentId is required otherwise this will not work.
           schema:
             type: string

--- a/backend/src/application/resources/submissionResource.ts
+++ b/backend/src/application/resources/submissionResource.ts
@@ -20,6 +20,7 @@ import * as SubmissionSchemas from "../schemas/submissionSchemas";
 
 const extractors = {
     getSubmission: deps.createZodParamsExtractor(SubmissionSchemas.getSubmissionSchema),
+    updateSubmission: deps.createZodParamsExtractor(SubmissionSchemas.updateSubmissionSchema),
     deleteSubmission: deps.createZodParamsExtractor(SubmissionSchemas.deleteSubmissionSchema),
     createSubmission: deps.createZodParamsExtractor(SubmissionSchemas.createSubmissionSchema),
     getUserSubmissions: deps.createZodParamsExtractor(SubmissionSchemas.getUserSubmissionsSchema),
@@ -30,11 +31,12 @@ const extractors = {
 export class SubmissionController extends deps.Controller {
     constructor(
         get: SubmissionServices.GetSubmission,
+        update: SubmissionServices.UpdateSubmission,
         remove: SubmissionServices.DeleteSubmission,
         create: SubmissionServices.CreateSubmission,
         getUserSubmissions: SubmissionServices.GetUserSubmissions,
     ) {
-        super({ get, remove, create, getUserSubmissions });
+        super({ get, update, remove, create, getUserSubmissions });
     }
 }
 
@@ -54,6 +56,15 @@ export function submissionRoutes(
                 controller,
                 extractor: extractors.getSubmission,
                 handler: (req, data) => controller.getOne(req, data),
+                middleware,
+            },
+            {
+                app,
+                method: deps.HttpMethod.PATCH,
+                urlPattern: "/submissions/:id",
+                controller,
+                extractor: extractors.updateSubmission,
+                handler: (req, data) => controller.update(req, data),
                 middleware,
             },
             {

--- a/backend/src/application/schemas/submissionSchemas.ts
+++ b/backend/src/application/schemas/submissionSchemas.ts
@@ -9,6 +9,10 @@ export const getSubmissionSchema = z.object({
     id: z.string(),
 });
 
+export const updateSubmissionSchema = z.object({
+    id: z.string(),
+});
+
 export const deleteSubmissionSchema = z.object({
     id: z.string(),
 });

--- a/backend/src/config/controllers.ts
+++ b/backend/src/config/controllers.ts
@@ -59,6 +59,7 @@ export const controllers = {
     ),
     submission: new Resources.SubmissionController(
         services.submission.get,
+        services.submission.update,
         services.submission.remove,
         services.submission.create,
         services.submission.getUserSubmissions,

--- a/backend/src/config/services.ts
+++ b/backend/src/config/services.ts
@@ -75,6 +75,7 @@ export const services = {
     },
     submission: {
         get: new SubmissionServices.GetSubmission(repos.submission),
+        update: new SubmissionServices.UpdateSubmission(repos.submission),
         remove: new SubmissionServices.DeleteSubmission(repos.submission),
         create: new SubmissionServices.CreateSubmission(repos.submission),
         getUserSubmissions: new SubmissionServices.GetUserSubmissions(repos.submission),

--- a/backend/src/core/repositories/submissionRepositoryInterface.ts
+++ b/backend/src/core/repositories/submissionRepositoryInterface.ts
@@ -20,6 +20,13 @@ export abstract class ISubmissionRepository extends AbstractRepository {
     public abstract getById(id: string): Promise<Submission>;
 
     /**
+     * Updates a submission from the repository.
+     * @param id - The submission to update.
+     * @returns A promise that resolves when the submission is deleted.
+     */
+    public abstract update(id: string): Promise<void>;
+
+    /**
      * Deletes a submission from the repository.
      * @param id - The submission to delete.
      * @returns A promise that resolves when the submission is deleted.

--- a/backend/src/core/services/submission/index.ts
+++ b/backend/src/core/services/submission/index.ts
@@ -1,3 +1,4 @@
 export * from "./createSubmission";
 export * from "./deleteSubmission";
 export * from "./getSubmission";
+export * from "./updateSubmission";

--- a/backend/src/core/services/submission/updateSubmission.ts
+++ b/backend/src/core/services/submission/updateSubmission.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import { SubmissionBaseService } from "./submissionBaseService";
+import { updateSubmissionSchema } from "../../../application/schemas";
+import { tryRepoEntityOperation } from "../../helpers";
+
+export type UpdateSubmissionInput = z.infer<typeof updateSubmissionSchema>;
+
+export class UpdateSubmission extends SubmissionBaseService<UpdateSubmissionInput> {
+    /**
+     * Executes the submission deletion process.
+     * @param input - The input data for deleting a submission, validated by updateSubmissionSchema.
+     * @returns An empty object.
+     * @throws {ApiError} If the submission with the given id is not found.
+     */
+    async execute(input: UpdateSubmissionInput): Promise<object> {
+        await tryRepoEntityOperation(this.submissionRepository.update(input.id), "Submission", input.id, true);
+        return {};
+    }
+}

--- a/backend/src/infrastructure/repositories/submissionRepositoryTypeORM.ts
+++ b/backend/src/infrastructure/repositories/submissionRepositoryTypeORM.ts
@@ -22,8 +22,8 @@ export class SubmissionRepositoryTypeORM extends ISubmissionRepository {
         return await this.datasourceSubmission.getById(id);
     }
 
-    public async update(submission: Submission): Promise<Submission> {
-        return await this.datasourceSubmission.update(submission);
+    public async update(id: string): Promise<void> {
+        return await this.datasourceSubmission.update(id);
     }
 
     public async delete(submissionId: string): Promise<void> {

--- a/backend/test/integration/submissions.int.test.ts
+++ b/backend/test/integration/submissions.int.test.ts
@@ -2,7 +2,6 @@ import { app } from "../../src/app";
 import request from "supertest";
 import { initializeUser, AuthDetails } from "./helpers";
 import { StatusType } from "../../src/core/entities/submission";
-let createdSubmissionId: string;
 
 describe('Test submission API endpoints', () => {
     let studentDetails: AuthDetails;
@@ -127,6 +126,25 @@ describe('Test submission API endpoints', () => {
         });
     });
 
+    describe('PATCH /submissions/:id', () => {
+        it('should update the submission', async () => {
+            const res = await request(app)
+                .patch(`/submissions/${createdSubmissionId}`)
+                .set('Content-Type', 'application/json')
+                .set("Authorization", "Bearer " + studentDetails.token);
+
+            expect(res.status).toBe(204);
+
+            const res2 = await request(app)
+                .get(`/submissions/${createdSubmissionId}`)
+                .set('Content-Type', 'application/json')
+                .set("Authorization", "Bearer " + studentDetails.token);
+
+            expect(res2.status).toBe(200);
+            expect(res2.body.status).toBe("not_accepted");
+        });
+    });
+
     describe('DELETE /submissions/:id', () => {
         it('should delete the submission', async () => {
             const res = await request(app)
@@ -149,6 +167,17 @@ describe('Test submission API endpoints', () => {
         it('should retrieve submissions of a user', async () => {
             const res = await request(app)
                 .get(`/users/${studentDetails.id}/submissions`)
+                .set('Content-Type', 'application/json')
+                .set("Authorization", "Bearer " + studentDetails.token);
+
+            expect(res.status).toBe(200);
+            expect(res.body).toHaveProperty('submissions');
+            expect(Array.isArray(res.body.submissions)).toBe(true);
+        });
+
+        it('should retrieve submissions of a user with query params', async () => {
+            const res = await request(app)
+                .get(`/users/${studentDetails.id}/submissions?assignmentId=` + assignmentId + `&taskId=` + taskId)
                 .set('Content-Type', 'application/json')
                 .set("Authorization", "Bearer " + studentDetails.token);
 

--- a/backend/test/unit/application/routes.test.ts
+++ b/backend/test/unit/application/routes.test.ts
@@ -501,6 +501,14 @@ const routeConfigs: Record<
             },
         },
         {
+            method: HttpMethod.PATCH,
+            path: "/submissions/:id",
+            hasController: true,
+            request: {
+                pathParams: { id: "submission-1" },
+            },
+        },
+        {
             method: HttpMethod.DELETE,
             path: "/submissions/:id",
             hasController: true,
@@ -681,7 +689,7 @@ const routeConfigs: Record<
             path: "/learningObject/:id",
             hasController: true,
             request: {
-                pathParams: {id: "ct08_05"},
+                pathParams: { id: "ct08_05" },
                 queryParams: { type: "raw" },
             },
         },
@@ -698,7 +706,7 @@ const routeConfigs: Record<
             path: "/learningPath/:id",
             hasController: true,
             request: {
-                pathParams: {id: "anm3"},
+                pathParams: { id: "anm3" },
                 queryParams: { type: "nl" },
             },
         },
@@ -761,19 +769,19 @@ const testRoutes = (
                 // Use route-specific request if provided, otherwise default
                 const req = request
                     ? {
-                          headers: {},
-                          method,
-                          body: request.body || {},
-                          pathParams: request.pathParams || {},
-                          queryParams: request.queryParams || {},
-                      }
+                        headers: {},
+                        method,
+                        body: request.body || {},
+                        pathParams: request.pathParams || {},
+                        queryParams: request.queryParams || {},
+                    }
                     : {
-                          headers: {},
-                          method,
-                          body: {},
-                          pathParams: { id: "test-id", idParent: "test-parent-id" },
-                          queryParams: {},
-                      };
+                        headers: {},
+                        method,
+                        body: {},
+                        pathParams: { id: "test-id", idParent: "test-parent-id" },
+                        queryParams: {},
+                    };
                 const res = { headers: {}, body: {}, status: 200 };
                 const next = jest.fn();
 

--- a/backend/test/unit/infrastructure/repositories/submissionRepositoryTypeORM.test.ts
+++ b/backend/test/unit/infrastructure/repositories/submissionRepositoryTypeORM.test.ts
@@ -38,6 +38,7 @@ describe("SubmissionRepositoryTypeORM", () => {
             new Date("01/04/2025"),
             new Buffer("OAPFOJIHUHZDOJDJ"),
             StatusType.NOT_ACCEPTED,
+            "submissionId"
         );
 
     });
@@ -61,12 +62,10 @@ describe("SubmissionRepositoryTypeORM", () => {
 
     test("update", async () => {
         // Call function from repository
-        submission.status = StatusType.ACCEPTED;
-        const updatedSubmission: Submission = await datasourceSubmission.update(submission);
+        await datasourceSubmission.update(submission.id!);
 
         expect(datasourceSubmission.update).toHaveBeenCalledTimes(1);
-        expect(datasourceSubmission.update).toHaveBeenCalledWith(submission);
-        expect(updatedSubmission.status).toEqual(submission.status);
+        expect(datasourceSubmission.update).toHaveBeenCalledWith(submission.id);
     });
 
     test("delete", async () => {

--- a/frontend/src/app/interfaces/tasks/getTasks.ts
+++ b/frontend/src/app/interfaces/tasks/getTasks.ts
@@ -1,4 +1,3 @@
-import { TaskType } from "./taskType";
 
 export interface GetTasksRequest {
     assignmentId: string;

--- a/frontend/src/app/services/task.service.spec.ts
+++ b/frontend/src/app/services/task.service.spec.ts
@@ -66,7 +66,7 @@ describe('TaskService', () => {
     });
 
     it('should retrieve a specific task from an assignment', () => {
-        http.get.and.callFake((url: string, options?: any) => {
+        http.get.and.callFake((url: string) => {
             if (url.endsWith('/assignments/assignment-id/tasks?step=1')) {
                 return of(getTasksResponse);
             }
@@ -74,6 +74,7 @@ describe('TaskService', () => {
                 return of(task);
             }
             // voor de zekerheid
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             return of(null as any);
         });
 


### PR DESCRIPTION
 * Closes #595 
 ## Changes
 * Added a PATCH method for submissions, when a patch is send to /submissions/:id -> It just changes the status to accepted when status not_accepted and vice versa
 * Fix the bug of not getting submissions when assignmentId and taskId is given.
 * Added integration tests for PATCH method and to recreate the bug under submissions.int.test.ts which both succeed after my fix.