### PR TITLE
[Frontend] - Fix assignment dates

### DIFF
--- a/frontend/src/app/components/create-assignment/create-assignment.component.ts
+++ b/frontend/src/app/components/create-assignment/create-assignment.component.ts
@@ -86,7 +86,6 @@ export class CreateAssignmentComponent implements OnInit {
 
   create(): void {
     const newAssignment: NewAssignment | null = this.extractFormValues();
-
     if (newAssignment) {
       this.assignmentService.createAssignment(newAssignment).subscribe((response) => {
 
@@ -131,11 +130,26 @@ export class CreateAssignmentComponent implements OnInit {
     const extraInstructions = this.createForm.get('extraInstructions')?.value;
 
     if (classId && startDate && deadline) {
+      // Make this safe date so converting to UTC doesn't change the day
+      // This can be done in a beter way and should be done in the future, but for now this fix works
+      const safeStart = new Date(
+      startDate.getFullYear(),
+      startDate.getMonth(),
+      startDate.getDate(),
+      12, 0, 0
+    );
+
+    const safeDeadline = new Date(
+      deadline.getFullYear(),
+      deadline.getMonth(),
+      deadline.getDate(),
+      12, 0, 0
+    );
       return {
         classId,
         learningPathId: this.learningPathId,
-        startDate,
-        deadline,
+        startDate: safeStart,
+        deadline: safeDeadline,
         extraInstructions,
         name
       };


### PR DESCRIPTION
- When creating an assignment, the `HTTP.post` would automatically convert this to _UTC_. Because of this when a startDate/deadline was created at *00:00* in a time zone like Brussels with +2 hours. This date would be one day earlier at 22:00.
- I fixed this by converting to date to noon (12:00) on that day, this way the _UTC_ conversion does not change the day of the date. 
- This is a fix that can be done in a cleaner way, by working with Date objects in a more consistent way. But for now this should suffise because we don't store hours in our DB for startdates/deadlines